### PR TITLE
feat: enables videocore on the rpi-cm3-64

### DIFF
--- a/conf/machine/raspberrypi-cm3-64.conf
+++ b/conf/machine/raspberrypi-cm3-64.conf
@@ -34,8 +34,7 @@ KERNEL_DEVICETREE = " \
     "
 
 SERIAL_CONSOLE ?= "115200 ttyS0"
-#VC4_CMA_SIZE ?= "cma-256"
+VC4_CMA_SIZE ?= "cma-256"
 
 UBOOT_MACHINE = "rpi_3_config"
-#MACHINE_FEATURES_append = " vc4graphics"
-KERNEL_DEFCONFIG ?= "bcmrpi3_defconfig"
+MACHINE_FEATURES_append = " vc4graphics"

--- a/recipes-bsp/bootfiles/rpi-config_git.bb
+++ b/recipes-bsp/bootfiles/rpi-config_git.bb
@@ -22,6 +22,8 @@ PITFT35r="${@bb.utils.contains("MACHINE_FEATURES", "pitft35r", "1", "0", d)}"
 
 VC4GRAPHICS="${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "1", "0", d)}"
 VC4DTBO_raspberrypi3-64 = "vc4-fkms-v3d"
+VC4DTBO_raspberrypi-cm3-64 = "vc4-fkms-v3d"
+
 VC4DTBO ?= "vc4-kms-v3d"
 inherit deploy
 


### PR DESCRIPTION
## What I did
enables videocore on the rpi-cm3-64 (used in the display test)

## How I did it
I took the setup for the rpi3 64bits and use them on the compute module

Also, removed `KERNEL_DEFCONFIG ?= "bcmrpi3_defconfig"` because it is already set in `recipes-kernel/linux/linux-raspberrypi.inc`
