### PR TITLE
fix: revert rpi3-64 dtbs append using HEAD of poky

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi.inc
+++ b/recipes-kernel/linux/linux-raspberrypi.inc
@@ -158,11 +158,6 @@ do_configure_prepend() {
 }
 
 do_compile_append_raspberrypi3-64() {
-    cc_extra=$(get_cc_option)
-    oe_runmake dtbs CC="${KERNEL_CC} $cc_extra " LD="${KERNEL_LD}" ${KERNEL_EXTRA_ARGS}
-}
-
-do_compile_append_raspberrypi3-64() {
     oe_runmake dtbs
 }
 


### PR DESCRIPTION
**- What I did**
Solves https://github.com/synapticon/NEOCORTEX-OS/issues/153

The issue is that `get_cc_option` has been created recently in kernel.bbclass in https://patchwork.openembedded.org/patch/143056/

I don't want to update the poky layer since it will lead to change of a lot of packages.
Also, this layer deletes the currently used GCC version. I could add it in the roboyagi layer manually but this would lead to more work and more tests to be done.

**- How I did**
I simply remove instead the lines creating the conflict using `git revert 6c4de0b5fe44b8e661f1391ee8540a7f04d75315`
