### PR TITLE
fix: use ssl to fetch rpio

### DIFF
--- a/recipes-devtools/python/rpio_0.10.0.bb
+++ b/recipes-devtools/python/rpio_0.10.0.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://README.rst;beginline=41;endline=53;md5=d5d95d7486a4d9
 
 SRCNAME = "RPIO"
 
-SRC_URI = "http://pypi.python.org/packages/source/R/RPIO/${SRCNAME}-${PV}.tar.gz \
+SRC_URI = "https://pypi.python.org/packages/source/R/RPIO/${SRCNAME}-${PV}.tar.gz \
            file://0001-include-sys-types.h-explicitly-for-getting-caddr_t-d.patch \
            "
 S = "${WORKDIR}/${SRCNAME}-${PV}"


### PR DESCRIPTION
**- What I did**
rpio requires SSL. I tried patching it upstream, but it was not accepted.

**- How I did it**
uses https instead of http